### PR TITLE
Modifications

### DIFF
--- a/PresentationController/ViewController.swift
+++ b/PresentationController/ViewController.swift
@@ -58,6 +58,27 @@ class PresentedController: UIViewController {
     @IBAction func dismissMe(_ sender: Any) {
         self.otf_dismiss(animated: true, completion: nil)
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NSLog("viewWillAppear - PresentedController")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NSLog("viewDidAppear - PresentedController")
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        NSLog("viewWillDisappear - PresentedController")
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NSLog("viewDidDisappear - PresentedController")
+    }
 }
 
 extension UIViewController: UIAdaptivePresentationControllerDelegate {
@@ -65,7 +86,6 @@ extension UIViewController: UIAdaptivePresentationControllerDelegate {
     public func presentationController(_ presentationController: UIPresentationController, willPresentWithAdaptiveStyle style: UIModalPresentationStyle, transitionCoordinator: UIViewControllerTransitionCoordinator?) {
         self.viewWillDisappear(true)
     }
-    
     
     public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
         let coordinator = presentationController.presentingViewController.transitionCoordinator
@@ -93,7 +113,8 @@ extension UIViewController {
         if (viewControllerToPresent.modalPresentationStyle == .automatic // this may be too conservative. `fullSheet` still leaves homeVC exposed
             || viewControllerToPresent.modalPresentationStyle == .pageSheet),
             let presentationController = viewControllerToPresent.presentationController,
-            presentationController.delegate == nil {
+            presentationController.delegate == nil
+        {
             presentationController.delegate = self
         }
         
@@ -101,14 +122,15 @@ extension UIViewController {
     }
     
     func otf_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        if self.modalPresentationStyle == .automatic
-            || self.modalPresentationStyle == .pageSheet {
-            self.presentationController?.presentingViewController.beginAppearanceTransition(true, animated: true)
-        }
         
+        guard self.modalPresentationStyle == .automatic
+            || self.modalPresentationStyle == .pageSheet
+            else { return self.dismiss(animated: flag, completion: completion) }
+        
+        self.presentationController?.presentingViewController.beginAppearanceTransition(true, animated: true)
         self.dismiss(animated: flag) {
             completion?()
-            self.endAppearanceTransition()
+            self.presentationController?.presentingViewController.endAppearanceTransition()
         }
     }
 }

--- a/PresentationController/ViewController.swift
+++ b/PresentationController/ViewController.swift
@@ -84,26 +84,26 @@ class PresentedController: UIViewController {
 extension UIViewController: UIAdaptivePresentationControllerDelegate {
 
     public func presentationController(_ presentationController: UIPresentationController, willPresentWithAdaptiveStyle style: UIModalPresentationStyle, transitionCoordinator: UIViewControllerTransitionCoordinator?) {
-        self.viewWillDisappear(true)
+        self.beginAppearanceTransition(false, animated: true) // this triggers `viewWillDisappear` for presenting VC
+        
     }
     
     public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
         let coordinator = presentationController.presentingViewController.transitionCoordinator
         coordinator?.notifyWhenInteractionChanges() { context in
             if context.completionVelocity > 0 {
-                self.beginAppearanceTransition(true, animated: true)
+                self.beginAppearanceTransition(true, animated: true) // this triggers `viewWillAppear` for presenting VC
             }
         }
     }
     
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        self.endAppearanceTransition()
+        self.endAppearanceTransition() // this triggers `viewDidAppear` for presenting VC
     }
     
     public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
         NSLog("\(String(describing: self)) is presentationControllerDidAttemptToDismiss")
     }
-    
     
 }
 
@@ -118,7 +118,10 @@ extension UIViewController {
             presentationController.delegate = self
         }
         
-        self.present(viewControllerToPresent, animated: flag, completion: completion)
+        self.present(viewControllerToPresent, animated: flag, completion: {
+            self.endAppearanceTransition() // this triggers `viewDidDisappear` for presenting VC
+            completion?()
+        })
     }
     
     func otf_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {

--- a/PresentationController/ViewController.swift
+++ b/PresentationController/ViewController.swift
@@ -77,7 +77,7 @@ extension UIViewController: UIAdaptivePresentationControllerDelegate {
     }
     
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        self.endAppearanceTransition()
+        self.endAppearanceTransition() 
     }
     
     public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {

--- a/PresentationController/ViewController.swift
+++ b/PresentationController/ViewController.swift
@@ -77,7 +77,7 @@ extension UIViewController: UIAdaptivePresentationControllerDelegate {
     }
     
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        self.endAppearanceTransition() 
+        self.endAppearanceTransition()
     }
     
     public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
@@ -99,6 +99,7 @@ extension UIViewController {
         
         self.present(viewControllerToPresent, animated: flag, completion: completion)
     }
+    
     func otf_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         if self.modalPresentationStyle == .automatic
             || self.modalPresentationStyle == .pageSheet {


### PR DESCRIPTION
`viewWillAppear` for dragging dismissal is triggered when user releases finger and the card is on a dismissal trajectory
`viewDidAppear` for dragging dismissal is triggered upon  `presentationControllerDidDismiss`

replaced `.viewWill/DidAppear` with `.begin/endAppearanceTransition(true_)`
replaced `.viewWill/DidDisappear` with `.begin/endAppearanceTransition(false:_)`

* Added logging to `PresentedController` to demonstrate that `vWDisappear` is triggered at beginning of drag gesture, `vWA` is triggered when touch is released and it begins to travel up, and `vDA` is triggered upon completion of the animation.
* Moved the modal check to a guard so that it applies to both begin/endTransition

* ~~**NOTE:** this still doesn't trigger the `didDisappear` call on the presenting controller~~

* added a couple comments